### PR TITLE
Implemented commands and let_syntax for commands

### DIFF
--- a/generated/Core_kernel.Bin_prot_generated_types.fsproj
+++ b/generated/Core_kernel.Bin_prot_generated_types.fsproj
@@ -26,7 +26,7 @@
          </ItemGroup>
 
          <ItemGroup>
-             <ProjectReference Include="../../../../lib/dotnet-libs/bin_prot/src/Bin_prot.fsproj" />
+             <ProjectReference Include="../../fsharp_bin_prot/src/Bin_prot.fsproj" />
          </ItemGroup>
 
          <Target Name="CleanOutputDirs" AfterTargets="Clean">

--- a/src/Command.fs
+++ b/src/Command.fs
@@ -1,0 +1,162 @@
+module Core_kernel.Command
+
+module Arg_type =
+    type 'a t = { parse: string -> 'a }
+    let create of_string = { parse = of_string }
+
+module Flag =
+    module Info =
+        type t =
+            { name: string
+              doc: string
+              no_arg: bool }
+
+    type 'a t =
+        { read: string option -> 'a
+          info: Info.t }
+
+    let required (arg_type: 'a Arg_type.t) (name: string) (doc: string) =
+        { read =
+            (function
+            | Some arg -> (arg_type.parse arg)
+            | None -> failwith ("Required flag " + name + " not supplied, refer to -help"))
+          info =
+            { name = name
+              doc = doc
+              no_arg = false } }
+
+    let optional (arg_type: 'a Arg_type.t) (name: string) (doc: string) =
+        { read =
+            (function
+            | Some arg -> Some(arg_type.parse arg)
+            | None -> None)
+          info =
+            { name = name
+              doc = doc
+              no_arg = false } }
+
+    let no_arg (name: string) (doc: string) =
+        { read =
+            (function
+            | Some _ -> true
+            | None -> false)
+          info =
+            { name = name
+              doc = doc
+              no_arg = true } }
+
+module Parser =
+    type 'a t = string list -> 'a * string list
+
+    let error_message flag =
+        "Unknown flag "
+        + flag
+        + ", refer to -help for possible flags"
+
+    let bind (x: 'a t) (f: 'a -> 'b t) =
+        fun (args: string list) ->
+            let parser_type, args = x args
+
+            if not (List.isEmpty args) then
+                failwith (error_message args[0])
+
+            (f parser_type) args
+
+    let map (x: 'a t) (f: 'a -> 'b) =
+        fun (args: string list) ->
+            let parser_type, args = x args
+
+            if not (List.isEmpty args) then
+                failwith (error_message args[0])
+
+            f parser_type, args
+
+    let both (x: 'a t) (y: 'b t) : ('a * 'b) t =
+        fun (args: string list) ->
+            let x_type, x_args = x args
+            let y_type, y_args = y x_args
+            (x_type, y_type), y_args
+
+    let return_ (x: 'a) = fun (args: string list) -> x, args
+    let zero () = fun (args: string list) -> (), args
+
+module Param =
+    type 'a t =
+        { parser: 'a Parser.t
+          flags: Flag.Info.t list }
+
+    let parse (t: 'a t) (args: string list) = t.parser args
+
+    let flag (f: 'a Flag.t) =
+        { parser =
+            fun args ->
+                if f.info.no_arg then
+                    match List.tryFindIndex (fun flag -> f.info.name = flag) args with
+                    | Some index -> f.read (Some(args[index])), List.removeAt index args
+                    | None -> f.read None, args
+                else
+                    match List.tryFindIndex (fun flag -> f.info.name = flag) args with
+                    | Some index ->
+                        let args = List.removeAt index args
+                        f.read (Some(args[index])), List.removeAt index args
+                    | None -> f.read None, args
+          flags = [ f.info ] }
+
+
+    let bind (x: 'a t) (f: 'a -> 'b t) =
+        let f x =
+            let f_param = f x
+            f_param.parser
+
+        { parser = Parser.bind x.parser f
+          flags = x.flags }
+
+    let map (x: 'a t) (f: 'a -> 'b) =
+        { parser = Parser.map x.parser f
+          flags = x.flags }
+
+    let both (x: 'a t) (y: 'b t) : ('a * 'b) t =
+        { parser = Parser.both x.parser y.parser
+          flags = x.flags @ y.flags }
+
+    let return_ (x: 'a) =
+        { parser = Parser.return_ x
+          flags = [] }
+
+    let zero () = { parser = Parser.zero (); flags = [] }
+
+    [<Sealed>]
+    type ResultBuilder() =
+        member __.Bind(x: 'a t, f: 'a -> 'b t) = bind x f
+        member __.BindReturn(x: 'a t, f: 'a -> 'b) = map x f
+        member __.MergeSources(x: 'a t, y: 'b t) = both x y
+        member __.Return(x: 'a) = return_ x
+        member __.Zero() = zero ()
+
+    let let_syntax = ResultBuilder()
+
+let run_exn (param: unit Param.t) (args: string list) =
+    if List.contains "-help" args then
+        printfn ""
+        printfn "possible flags:"
+        printfn ""
+        let possible_flags = param.flags
+
+        for flag in possible_flags do
+            let name = flag.name
+            let doc = flag.doc
+            printfn "%-*s %s" 20 name doc
+
+        printfn ""
+    else
+        (* Since unit Param.t always returns a unit and there should be no remaining arguments in the string list,
+           we can ignore what is returned here *)
+        let (_: unit), (_: string list) = Param.parse param args
+        ()
+
+let run (param: unit Param.t) (args: string list) =
+    match Or_error.try_with (fun () -> run_exn param args) with
+    | Ok _ -> 0
+    | Error error ->
+        printfn "%A" error
+        1

--- a/src/Command.fs
+++ b/src/Command.fs
@@ -1,162 +1,198 @@
 module Core_kernel.Command
 
 module Arg_type =
-    type 'a t = { parse: string -> 'a }
-    let create of_string = { parse = of_string }
+  type 'a t = { parse : string -> 'a }
+  let create of_string = { parse = of_string }
 
 module Flag =
-    module Info =
-        type t =
-            { name: string
-              doc: string
-              no_arg: bool }
+  module Info =
+    type t =
+      { name : string
+        doc : string
+        aliases : string list
+        no_arg : bool }
 
-    type 'a t =
-        { read: string option -> 'a
-          info: Info.t }
+  type 'a t =
+    { read : string option -> 'a
+      info : Info.t }
 
-    let required (arg_type: 'a Arg_type.t) (name: string) (doc: string) =
-        { read =
-            (function
-            | Some arg -> (arg_type.parse arg)
-            | None -> failwith ("Required flag " + name + " not supplied, refer to -help"))
-          info =
-            { name = name
-              doc = doc
-              no_arg = false } }
+  let required
+    (arg_type : 'a Arg_type.t)
+    (name : string)
+    (doc : string)
+    (aliases : string list)
+    =
+    { read =
+        (function
+        | Some arg -> (arg_type.parse arg)
+        | None ->
+          failwith (
+            "Required flag "
+            + name
+            + " not supplied, refer to -help"
+          ))
+      info =
+        { name = name
+          doc = doc
+          aliases = aliases
+          no_arg = false } }
 
-    let optional (arg_type: 'a Arg_type.t) (name: string) (doc: string) =
-        { read =
-            (function
-            | Some arg -> Some(arg_type.parse arg)
-            | None -> None)
-          info =
-            { name = name
-              doc = doc
-              no_arg = false } }
+  let optional
+    (arg_type : 'a Arg_type.t)
+    (name : string)
+    (doc : string)
+    (aliases : string list)
+    =
+    { read =
+        (function
+        | Some arg -> Some(arg_type.parse arg)
+        | None -> None)
+      info =
+        { name = name
+          doc = doc
+          aliases = aliases
+          no_arg = false } }
 
-    let no_arg (name: string) (doc: string) =
-        { read =
-            (function
-            | Some _ -> true
-            | None -> false)
-          info =
-            { name = name
-              doc = doc
-              no_arg = true } }
+  let no_arg (name : string) (doc : string) (aliases : string list) =
+    { read =
+        (function
+        | Some _ -> true
+        | None -> false)
+      info =
+        { name = name
+          doc = doc
+          aliases = aliases
+          no_arg = true } }
 
 module Parser =
-    type 'a t = string list -> 'a * string list
+  type 'a t = string list -> 'a * string list
 
-    let error_message flag =
-        "Unknown flag "
-        + flag
-        + ", refer to -help for possible flags"
+  let error_message flag =
+    "Unknown flag "
+    + flag
+    + ", refer to -help for possible flags"
 
-    let bind (x: 'a t) (f: 'a -> 'b t) =
-        fun (args: string list) ->
-            let parser_type, args = x args
+  let bind (x : 'a t) (f : 'a -> 'b t) =
+    fun (args : string list) ->
+      let parser_type, args = x args
 
-            if not (List.isEmpty args) then
-                failwith (error_message args[0])
+      if not (List.isEmpty args) then
+        failwith (error_message args[0])
 
-            (f parser_type) args
+      (f parser_type) args
 
-    let map (x: 'a t) (f: 'a -> 'b) =
-        fun (args: string list) ->
-            let parser_type, args = x args
+  let map (x : 'a t) (f : 'a -> 'b) =
+    fun (args : string list) ->
+      let parser_type, args = x args
 
-            if not (List.isEmpty args) then
-                failwith (error_message args[0])
+      if not (List.isEmpty args) then
+        failwith (error_message args[0])
 
-            f parser_type, args
+      f parser_type, args
 
-    let both (x: 'a t) (y: 'b t) : ('a * 'b) t =
-        fun (args: string list) ->
-            let x_type, x_args = x args
-            let y_type, y_args = y x_args
-            (x_type, y_type), y_args
+  let both (x : 'a t) (y : 'b t) : ('a * 'b) t =
+    fun (args : string list) ->
+      let x_type, x_args = x args
+      let y_type, y_args = y x_args
+      (x_type, y_type), y_args
 
-    let return_ (x: 'a) = fun (args: string list) -> x, args
-    let zero () = fun (args: string list) -> (), args
+  let return_ (x : 'a) = fun (args : string list) -> x, args
+  let zero () = fun (args : string list) -> (), args
 
 module Param =
-    type 'a t =
-        { parser: 'a Parser.t
-          flags: Flag.Info.t list }
+  type 'a t =
+    { parser : 'a Parser.t
+      flags : Flag.Info.t list }
 
-    let parse (t: 'a t) (args: string list) = t.parser args
+  let parse (t : 'a t) (args : string list) = t.parser args
 
-    let flag (f: 'a Flag.t) =
-        { parser =
-            fun args ->
-                if f.info.no_arg then
-                    match List.tryFindIndex (fun flag -> f.info.name = flag) args with
-                    | Some index -> f.read (Some(args[index])), List.removeAt index args
-                    | None -> f.read None, args
-                else
-                    match List.tryFindIndex (fun flag -> f.info.name = flag) args with
-                    | Some index ->
-                        let args = List.removeAt index args
-                        f.read (Some(args[index])), List.removeAt index args
-                    | None -> f.read None, args
-          flags = [ f.info ] }
+  let rec check_aliases (args : string list) (aliases : string list) =
+    match aliases with
+    | head :: tail ->
+      match List.tryFindIndex (fun flag -> head = flag) args with
+      | Some index -> Some(index)
+      | None -> check_aliases args tail
+    | [] -> None
+
+  let flag (f : 'a Flag.t) =
+    { parser =
+        fun args ->
+          if f.info.no_arg then
+            match List.tryFindIndex (fun flag -> f.info.name = flag) args with
+            | Some index -> f.read (Some(args[index])), List.removeAt index args
+            | None ->
+              match (check_aliases args f.info.aliases) with
+              | Some index -> f.read (Some(args[index])), List.removeAt index args
+              | None -> f.read None, args
+          else
+            match List.tryFindIndex (fun flag -> f.info.name = flag) args with
+            | Some index ->
+              let args = List.removeAt index args
+              f.read (Some(args[index])), List.removeAt index args
+            | None ->
+              match (check_aliases args f.info.aliases) with
+              | Some index ->
+                let args = List.removeAt index args
+                f.read (Some(args[index])), List.removeAt index args
+              | None -> f.read None, args
+      flags = [ f.info ] }
 
 
-    let bind (x: 'a t) (f: 'a -> 'b t) =
-        let f x =
-            let f_param = f x
-            f_param.parser
+  let bind (x : 'a t) (f : 'a -> 'b t) =
+    let f x =
+      let f_param = f x
+      f_param.parser
 
-        { parser = Parser.bind x.parser f
-          flags = x.flags }
+    { parser = Parser.bind x.parser f
+      flags = x.flags }
 
-    let map (x: 'a t) (f: 'a -> 'b) =
-        { parser = Parser.map x.parser f
-          flags = x.flags }
+  let map (x : 'a t) (f : 'a -> 'b) =
+    { parser = Parser.map x.parser f
+      flags = x.flags }
 
-    let both (x: 'a t) (y: 'b t) : ('a * 'b) t =
-        { parser = Parser.both x.parser y.parser
-          flags = x.flags @ y.flags }
+  let both (x : 'a t) (y : 'b t) : ('a * 'b) t =
+    { parser = Parser.both x.parser y.parser
+      flags = x.flags @ y.flags }
 
-    let return_ (x: 'a) =
-        { parser = Parser.return_ x
-          flags = [] }
+  let return_ (x : 'a) =
+    { parser = Parser.return_ x
+      flags = [] }
 
-    let zero () = { parser = Parser.zero (); flags = [] }
+  let zero () = { parser = Parser.zero (); flags = [] }
 
-    [<Sealed>]
-    type ResultBuilder() =
-        member __.Bind(x: 'a t, f: 'a -> 'b t) = bind x f
-        member __.BindReturn(x: 'a t, f: 'a -> 'b) = map x f
-        member __.MergeSources(x: 'a t, y: 'b t) = both x y
-        member __.Return(x: 'a) = return_ x
-        member __.Zero() = zero ()
+  [<Sealed>]
+  type ResultBuilder () =
+    member __.Bind(x : 'a t, f : 'a -> 'b t) = bind x f
+    member __.BindReturn(x : 'a t, f : 'a -> 'b) = map x f
+    member __.MergeSources(x : 'a t, y : 'b t) = both x y
+    member __.Return(x : 'a) = return_ x
+    member __.Zero() = zero ()
 
-    let let_syntax = ResultBuilder()
+  let let_syntax = ResultBuilder()
 
-let run_exn (param: unit Param.t) (args: string list) =
-    if List.contains "-help" args then
-        printfn ""
-        printfn "possible flags:"
-        printfn ""
-        let possible_flags = param.flags
+let run_exn (param : unit Param.t) (args : string list) =
+  if List.contains "-help" args
+     || List.contains "--h" args then
+    printfn ""
+    printfn "possible flags:"
+    printfn ""
+    let possible_flags = param.flags
 
-        for flag in possible_flags do
-            let name = flag.name
-            let doc = flag.doc
-            printfn "%-*s %s" 20 name doc
+    for flag in possible_flags do
+      let name = flag.name
+      let doc = flag.doc
+      printfn "%-*s %s" 20 name doc
 
-        printfn ""
-    else
-        (* Since unit Param.t always returns a unit and there should be no remaining arguments in the string list,
+    printfn ""
+  else
+    (* Since unit Param.t always returns a unit and there should be no remaining arguments in the string list,
            we can ignore what is returned here *)
-        let (_: unit), (_: string list) = Param.parse param args
-        ()
+    let (_ : unit), (_ : string list) = Param.parse param args
+    ()
 
-let run (param: unit Param.t) (args: string list) =
-    match Or_error.try_with (fun () -> run_exn param args) with
-    | Ok _ -> 0
-    | Error error ->
-        printfn "%A" error
-        1
+let run (param : unit Param.t) (args : string list) =
+  match Or_error.try_with (fun () -> run_exn param args) with
+  | Ok _ -> 0
+  | Error error ->
+    printfn "%A" error
+    1

--- a/src/Command.fsi
+++ b/src/Command.fsi
@@ -1,29 +1,34 @@
 module Core_kernel.Command
 
 module Arg_type =
-    type 'a t
-    val create: (string -> 'a) -> 'a t
+  type 'a t
+  val create : (string -> 'a) -> 'a t
 
 module Flag =
-    type 'a t
-    val required: 'a Arg_type.t -> name: string -> doc: string -> 'a t
-    val optional: 'a Arg_type.t -> name: string -> doc: string -> 'a option t
-    val no_arg: name: string -> doc: string -> bool t
+  type 'a t
+
+  val required :
+    'a Arg_type.t -> name : string -> doc : string -> aliases : string list -> 'a t
+
+  val optional :
+    'a Arg_type.t -> name : string -> doc : string -> aliases : string list -> 'a option t
+
+  val no_arg : name : string -> doc : string -> aliases : string list -> bool t
 
 module Param =
-    type 'a t
-    val parse: 'a t -> string list -> 'a * string list
-    val flag: 'a Flag.t -> 'a t
+  type 'a t
+  val parse : 'a t -> string list -> 'a * string list
+  val flag : 'a Flag.t -> 'a t
 
-    [<Sealed>]
-    type ResultBuilder =
-        member Bind: 'a t * ('a -> 'b t) -> 'b t
-        member MergeSources: 'a t * 'b t -> ('a * 'b) t
-        member BindReturn: 'a t * ('a -> 'b) -> 'b t
-        member Return: 'a -> 'a t
-        member Zero: unit -> unit t
+  [<Sealed>]
+  type ResultBuilder =
+    member Bind : 'a t * ('a -> 'b t) -> 'b t
+    member MergeSources : 'a t * 'b t -> ('a * 'b) t
+    member BindReturn : 'a t * ('a -> 'b) -> 'b t
+    member Return : 'a -> 'a t
+    member Zero : unit -> unit t
 
-    val let_syntax: ResultBuilder
+  val let_syntax : ResultBuilder
 
-val run_exn: unit Param.t -> string list -> unit
-val run: unit Param.t -> string list -> int
+val run_exn : unit Param.t -> string list -> unit
+val run : unit Param.t -> string list -> int

--- a/src/Command.fsi
+++ b/src/Command.fsi
@@ -1,0 +1,29 @@
+module Core_kernel.Command
+
+module Arg_type =
+    type 'a t
+    val create: (string -> 'a) -> 'a t
+
+module Flag =
+    type 'a t
+    val required: 'a Arg_type.t -> name: string -> doc: string -> 'a t
+    val optional: 'a Arg_type.t -> name: string -> doc: string -> 'a option t
+    val no_arg: name: string -> doc: string -> bool t
+
+module Param =
+    type 'a t
+    val parse: 'a t -> string list -> 'a * string list
+    val flag: 'a Flag.t -> 'a t
+
+    [<Sealed>]
+    type ResultBuilder =
+        member Bind: 'a t * ('a -> 'b t) -> 'b t
+        member MergeSources: 'a t * 'b t -> ('a * 'b) t
+        member BindReturn: 'a t * ('a -> 'b) -> 'b t
+        member Return: 'a -> 'a t
+        member Zero: unit -> unit t
+
+    val let_syntax: ResultBuilder
+
+val run_exn: unit Param.t -> string list -> unit
+val run: unit Param.t -> string list -> int

--- a/src/Core_kernel.fsproj
+++ b/src/Core_kernel.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- This is named [Core_kernel] instead of [Core] since [Core] aliases to [Fsharp.Core] -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
@@ -11,7 +11,6 @@
     <EmbedAllSources>true</EmbedAllSources>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="Either.fsi" />
     <Compile Include="Either.fs" />
@@ -67,6 +66,8 @@
     <Compile Include="IPAddress.fs" />
     <Compile Include="User_groups.fsi" />
     <Compile Include="User_groups.fs" />
+    <Compile Include="Command.fsi" />
+    <Compile Include="Command.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\generated\Core_kernel.Bin_prot_generated_types.fsproj" />

--- a/test/Command_test.fs
+++ b/test/Command_test.fs
@@ -1,0 +1,157 @@
+module Core_kernel.Test.Command
+
+open NUnit.Framework
+open Core_kernel.Command
+open System
+open System.IO
+
+module Req_test =
+    type t = { length: int }
+
+    let (req_arg: t Arg_type.t) =
+        Arg_type.create (fun string -> { length = String.length string })
+
+    let (req_flag: t Flag.t) =
+        Flag.required
+            (req_arg: t Arg_type.t)
+            "-req"
+            "Testing required arg: returns a record of the length of the arg string"
+
+    let (req_param: t Param.t) = Param.flag (req_flag: t Flag.t)
+
+module No_arg_test =
+    type t = bool
+
+    let (no_arg_flag: t Flag.t) =
+        Flag.no_arg "-no_arg" "Testing no arg: returns true if flag is present, false otherwise"
+
+    let (no_arg_param: t Param.t) = Param.flag (no_arg_flag: t Flag.t)
+
+module Opt_test =
+    type t = string
+    let (opt_arg: t Arg_type.t) = Arg_type.create (fun string -> string)
+
+    let (opt_flag: t option Flag.t) =
+        Flag.optional (opt_arg: t Arg_type.t) "-opt" "Testing optional arg: returns the arg string"
+
+    let (opt_param: t option Param.t) = Param.flag (opt_flag: t option Flag.t)
+
+module Test =
+    type t = string
+    let (test_arg: t Arg_type.t) = Arg_type.create (fun string -> string)
+
+    let (test_flag: t Flag.t) =
+        Flag.required (test_arg: t Arg_type.t) "-test" "Test flag doc"
+
+    let (test_param: t Param.t) = Param.flag (test_flag: t Flag.t)
+
+
+let run_test
+    (expected_output: (string * bool * string) list)
+    (param: (string * No_arg_test.t * string) list Param.t)
+    (args: string list)
+    =
+    let x, _ = Param.parse param args
+    Assert.AreEqual(expected_output, x)
+
+
+[<Test>]
+[<Category("Command_tests")>]
+let ``flags`` () =
+    let create_arg_string req opt no_arg =
+        match opt with
+        | Some opt -> [ req.ToString(), no_arg, opt ]
+        | None -> [ req.ToString(), no_arg, "no opt" ]
+
+    let req_param = Req_test.req_param
+    let no_arg_param = No_arg_test.no_arg_param
+    let opt_param = Opt_test.opt_param
+
+    let x =
+        Param.let_syntax {
+            let! (req: Req_test.t) = (req_param: Req_test.t Param.t)
+            and! (no_arg: No_arg_test.t) = (no_arg_param: No_arg_test.t Param.t)
+            and! (opt: Opt_test.t option) = (opt_param: Opt_test.t option Param.t)
+
+            return create_arg_string req opt no_arg
+        }
+
+    let required_args = [ "{ length = 4 }", false, "no opt" ]
+    run_test required_args x [ "-req"; "test" ]
+
+    let optional_args = [ "{ length = 4 }", false, "opt" ]
+    run_test optional_args x [ "-req"; "test"; "-opt"; "opt" ]
+
+    let no_args = [ "{ length = 4 }", true, "no opt" ]
+    run_test no_args x [ "-req"; "test"; "-no_arg" ]
+
+[<Test>]
+[<Category("Command_tests")>]
+let ``help_test`` () =
+    use string_writer = new StringWriter()
+    Console.SetOut(string_writer)
+
+    let test_param = Test.test_param
+
+    let x =
+        Param.let_syntax {
+            let! (test: Test.t) = (test_param: Test.t Param.t)
+            return printf "%A" test
+        }
+
+    Assert.AreEqual(0, (run x [ "-help" ]))
+    let output = string_writer.ToString()
+
+    let expected_output =
+        "
+possible flags:
+
+-test                Test flag doc
+
+"
+
+    Assert.AreEqual(output, expected_output)
+
+[<Test>]
+[<Category("Command_tests")>]
+let ``unknown_flag`` () =
+    use string_writer = new StringWriter()
+    Console.SetOut(string_writer)
+
+    let test_param = Opt_test.opt_param
+
+    let x =
+        Param.let_syntax {
+            let! (test: Test.t option) = (test_param: Test.t option Param.t)
+            return printf "%A" test
+        }
+
+    Assert.AreEqual(1, run x [ "-unknown" ])
+    let output = string_writer.ToString().Split("\n")
+
+    let expected_output =
+        "String  \"System.Exception: Unknown flag -unknown, refer to -help for possible flags"
+
+    Assert.AreEqual(output[0] + output[1], expected_output)
+
+[<Test>]
+[<Category("Command_tests")>]
+let ``no_required_arg`` () =
+    use string_writer = new StringWriter()
+    Console.SetOut(string_writer)
+
+    let test_param = Test.test_param
+
+    let x =
+        Param.let_syntax {
+            let! (test: Test.t) = (test_param: Test.t Param.t)
+            return printf "%A" test
+        }
+
+    Assert.AreEqual(1, run x [])
+    let output = string_writer.ToString().Split("\n")
+
+    let expected_output =
+        "String  \"System.Exception: Required flag -test not supplied, refer to -help"
+
+    Assert.AreEqual(output[0] + output[1], expected_output)

--- a/test/Command_test.fs
+++ b/test/Command_test.fs
@@ -6,152 +6,160 @@ open System
 open System.IO
 
 module Req_test =
-    type t = { length: int }
+  type t = { length : int }
 
-    let (req_arg: t Arg_type.t) =
-        Arg_type.create (fun string -> { length = String.length string })
+  let (req_arg : t Arg_type.t) =
+    Arg_type.create (fun string -> { length = String.length string })
 
-    let (req_flag: t Flag.t) =
-        Flag.required
-            (req_arg: t Arg_type.t)
-            "-req"
-            "Testing required arg: returns a record of the length of the arg string"
+  let (req_flag : t Flag.t) =
+    Flag.required
+      (req_arg : t Arg_type.t)
+      "-req"
+      "Testing required arg: returns a record of the length of the arg string"
+      [ "--r" ]
 
-    let (req_param: t Param.t) = Param.flag (req_flag: t Flag.t)
+  let (req_param : t Param.t) = Param.flag (req_flag : t Flag.t)
 
 module No_arg_test =
-    type t = bool
+  type t = bool
 
-    let (no_arg_flag: t Flag.t) =
-        Flag.no_arg "-no_arg" "Testing no arg: returns true if flag is present, false otherwise"
+  let (no_arg_flag : t Flag.t) =
+    Flag.no_arg
+      "-no_arg"
+      "Testing no arg: returns true if flag is present, false otherwise"
+      [ "--na"; "-no" ]
 
-    let (no_arg_param: t Param.t) = Param.flag (no_arg_flag: t Flag.t)
+  let (no_arg_param : t Param.t) = Param.flag (no_arg_flag : t Flag.t)
 
 module Opt_test =
-    type t = string
-    let (opt_arg: t Arg_type.t) = Arg_type.create (fun string -> string)
+  type t = string
+  let (opt_arg : t Arg_type.t) = Arg_type.create (fun string -> string)
 
-    let (opt_flag: t option Flag.t) =
-        Flag.optional (opt_arg: t Arg_type.t) "-opt" "Testing optional arg: returns the arg string"
+  let (opt_flag : t option Flag.t) =
+    Flag.optional
+      (opt_arg : t Arg_type.t)
+      "-opt"
+      "Testing optional arg: returns the arg string"
+      [ "--o" ]
 
-    let (opt_param: t option Param.t) = Param.flag (opt_flag: t option Flag.t)
+  let (opt_param : t option Param.t) = Param.flag (opt_flag : t option Flag.t)
 
 module Test =
-    type t = string
-    let (test_arg: t Arg_type.t) = Arg_type.create (fun string -> string)
+  type t = string
+  let (test_arg : t Arg_type.t) = Arg_type.create (fun string -> string)
 
-    let (test_flag: t Flag.t) =
-        Flag.required (test_arg: t Arg_type.t) "-test" "Test flag doc"
+  let (test_flag : t Flag.t) =
+    Flag.required (test_arg : t Arg_type.t) "-test" "Test flag doc" []
 
-    let (test_param: t Param.t) = Param.flag (test_flag: t Flag.t)
+  let (test_param : t Param.t) = Param.flag (test_flag : t Flag.t)
 
 
 let run_test
-    (expected_output: (string * bool * string) list)
-    (param: (string * No_arg_test.t * string) list Param.t)
-    (args: string list)
-    =
-    let x, _ = Param.parse param args
-    Assert.AreEqual(expected_output, x)
+  (expected_output : (string * bool * string) list)
+  (param : (string * No_arg_test.t * string) list Param.t)
+  (args : string list)
+  =
+  let x, _ = Param.parse param args
+  Assert.AreEqual(expected_output, x)
 
+let test_printed_output
+  (param : unit Param.t)
+  (args : string list)
+  (expected_exit_code : int)
+  (expected_output : string list)
+  (lines_of_output : int)
+  =
+  use string_writer = new StringWriter()
+  Console.SetOut(string_writer)
+  Assert.AreEqual(expected_exit_code, (run param args))
+
+  let output =
+    string_writer.ToString().Split("\n")
+    |> Array.toList
+    |> List.take lines_of_output
+
+  Assert.AreEqual(expected_output, output)
 
 [<Test>]
 [<Category("Command_tests")>]
 let ``flags`` () =
-    let create_arg_string req opt no_arg =
-        match opt with
-        | Some opt -> [ req.ToString(), no_arg, opt ]
-        | None -> [ req.ToString(), no_arg, "no opt" ]
+  let create_arg_string req opt no_arg =
+    match opt with
+    | Some opt -> [ req.ToString(), no_arg, opt ]
+    | None -> [ req.ToString(), no_arg, "no opt" ]
 
-    let req_param = Req_test.req_param
-    let no_arg_param = No_arg_test.no_arg_param
-    let opt_param = Opt_test.opt_param
+  let req_param = Req_test.req_param
+  let no_arg_param = No_arg_test.no_arg_param
+  let opt_param = Opt_test.opt_param
 
-    let x =
-        Param.let_syntax {
-            let! (req: Req_test.t) = (req_param: Req_test.t Param.t)
-            and! (no_arg: No_arg_test.t) = (no_arg_param: No_arg_test.t Param.t)
-            and! (opt: Opt_test.t option) = (opt_param: Opt_test.t option Param.t)
+  let x =
+    Param.let_syntax {
+      let! (req : Req_test.t) = (req_param : Req_test.t Param.t)
+      and! (no_arg : No_arg_test.t) = (no_arg_param : No_arg_test.t Param.t)
+      and! (opt : Opt_test.t option) = (opt_param : Opt_test.t option Param.t)
 
-            return create_arg_string req opt no_arg
-        }
+      return create_arg_string req opt no_arg
+    }
 
-    let required_args = [ "{ length = 4 }", false, "no opt" ]
-    run_test required_args x [ "-req"; "test" ]
+  let required_args = [ "{ length = 4 }", false, "no opt" ]
+  run_test required_args x [ "-req"; "test" ]
 
-    let optional_args = [ "{ length = 4 }", false, "opt" ]
-    run_test optional_args x [ "-req"; "test"; "-opt"; "opt" ]
+  let optional_args = [ "{ length = 4 }", false, "opt" ]
+  run_test optional_args x [ "-req"; "test"; "-opt"; "opt" ]
 
-    let no_args = [ "{ length = 4 }", true, "no opt" ]
-    run_test no_args x [ "-req"; "test"; "-no_arg" ]
+  let no_args = [ "{ length = 4 }", true, "no opt" ]
+  run_test no_args x [ "-req"; "test"; "-no_arg" ]
+
+  let aliases = [ "{ length = 4 }", true, "opt" ]
+  run_test aliases x [ "--r"; "test"; "-no"; "--o"; "opt" ]
 
 [<Test>]
 [<Category("Command_tests")>]
 let ``help_test`` () =
-    use string_writer = new StringWriter()
-    Console.SetOut(string_writer)
+  let test_param = Test.test_param
 
-    let test_param = Test.test_param
+  let x =
+    Param.let_syntax {
+      let! (test : Test.t) = (test_param : Test.t Param.t)
+      return printf "%A" test
+    }
 
-    let x =
-        Param.let_syntax {
-            let! (test: Test.t) = (test_param: Test.t Param.t)
-            return printf "%A" test
-        }
+  let expected_output =
+    [ ""; "possible flags:"; ""; "-test                Test flag doc" ]
 
-    Assert.AreEqual(0, (run x [ "-help" ]))
-    let output = string_writer.ToString()
-
-    let expected_output =
-        "
-possible flags:
-
--test                Test flag doc
-
-"
-
-    Assert.AreEqual(output, expected_output)
+  test_printed_output x [ "-help" ] 0 expected_output 4
+  test_printed_output x [ "--h" ] 0 expected_output 4
 
 [<Test>]
 [<Category("Command_tests")>]
 let ``unknown_flag`` () =
-    use string_writer = new StringWriter()
-    Console.SetOut(string_writer)
 
-    let test_param = Opt_test.opt_param
+  let test_param = Opt_test.opt_param
 
-    let x =
-        Param.let_syntax {
-            let! (test: Test.t option) = (test_param: Test.t option Param.t)
-            return printf "%A" test
-        }
+  let x =
+    Param.let_syntax {
+      let! (test : Test.t option) = (test_param : Test.t option Param.t)
+      return printf "%A" test
+    }
 
-    Assert.AreEqual(1, run x [ "-unknown" ])
-    let output = string_writer.ToString().Split("\n")
+  let expected_output =
+    [ "String"
+      "  \"System.Exception: Unknown flag -unknown, refer to -help for possible flags" ]
 
-    let expected_output =
-        "String  \"System.Exception: Unknown flag -unknown, refer to -help for possible flags"
-
-    Assert.AreEqual(output[0] + output[1], expected_output)
+  test_printed_output x [ "-unknown" ] 1 expected_output 2
 
 [<Test>]
 [<Category("Command_tests")>]
 let ``no_required_arg`` () =
-    use string_writer = new StringWriter()
-    Console.SetOut(string_writer)
+  let test_param = Test.test_param
 
-    let test_param = Test.test_param
+  let x =
+    Param.let_syntax {
+      let! (test : Test.t) = (test_param : Test.t Param.t)
+      return printf "%A" test
+    }
 
-    let x =
-        Param.let_syntax {
-            let! (test: Test.t) = (test_param: Test.t Param.t)
-            return printf "%A" test
-        }
+  let expected_output =
+    [ "String"; "  \"System.Exception: Required flag -test not supplied, refer to -help" ]
 
-    Assert.AreEqual(1, run x [])
-    let output = string_writer.ToString().Split("\n")
-
-    let expected_output =
-        "String  \"System.Exception: Required flag -test not supplied, refer to -help"
-
-    Assert.AreEqual(output[0] + output[1], expected_output)
+  test_printed_output x [] 1 expected_output 2

--- a/test/Core_kernel.Test.fsproj
+++ b/test/Core_kernel.Test.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="Log_test.fs" />
     <Compile Include="User_groups_test.fs" />
     <Compile Include="Map_test.fs" />
+    <Compile Include="Command_test.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
An applicative interface for Command that parses a string list of required, optional, and no-arg flags and their potential arguments. The parser converts string list -> 'a * string list where the original string list of flags and arguments is changed to a 'a, the parsed value of the flag with its argument, and a string list of the remaining flags and arguments. Let_syntax combines the parsers of each flag to parse the entire string list input at once. It also allows for clean formatting. Additionally, -help allows users to see the possible flags and their docs.

Testing accounts for a required flag, optional flag, and no_arg flag with different 'a values like a record of an int and a string. The output of -help is tested with one required flag with a doc. The error message from an unknown input and from missing a required flag are tested. These flags and error messages are tested by comparing an expected string or string list output to the actual output.

Signed-off-by: Jade <jadekessinger13@gmail.com>